### PR TITLE
Reordering keywords to fix cmake build in macos/clang

### DIFF
--- a/tinyutf8.cpp
+++ b/tinyutf8.cpp
@@ -2,5 +2,5 @@
 
 // Explicit template instantiations for utf8_string
 template struct tiny_utf8::basic_utf8_string<>;
-template extern std::ostream& operator<<( std::ostream& stream , const tiny_utf8::basic_utf8_string<>& str );
-template extern std::istream& operator>>( std::istream& stream , tiny_utf8::basic_utf8_string<>& str );
+extern template std::ostream& operator<<( std::ostream& stream , const tiny_utf8::basic_utf8_string<>& str );
+extern template std::istream& operator>>( std::istream& stream , tiny_utf8::basic_utf8_string<>& str );


### PR DESCRIPTION
Hi again! 

I ran into a compile issue with cmake on macos where I was trying to link tinyutf8 as a library. To make it work I had to flip these keywords to make it build. I figured I'd send it your way, but I honestly don't know as much about explicit template instantiation to know if the order matters. 

Hope that helps!
Evan

