### PR TITLE
Ignore GCC warning about uninitialized variables.

### DIFF
--- a/include/tinyutf8/tinyutf8.h
+++ b/include/tinyutf8/tinyutf8.h
@@ -79,6 +79,7 @@
 	// #pragma clang diagnostic ignored "-Wmaybe-uninitialized" // Clang is missing it. See https://bugs.llvm.org/show_bug.cgi?id=24979
 #elif defined(__GNUC__)
 	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #elif defined(_MSC_VER)
 	#pragma warning(push)
 	#pragma warning(disable:4701) // Maybe unitialized


### PR DESCRIPTION
@DuffsDevice First of all, really cool project! It just makes it so much easier to deal with UTF-8 data.

When compiling my code with tinyutf8 with gcc, I got the following error:

```
      In file included from ...:
      .../third-party/tiny-utf8/include/tinyutf8/tinyutf8.h: In member function 'tiny_utf8::basic_string<V, D, A> tiny_utf8::basic_string<ValueType, DataType, Allocator>::raw_substr(tiny_utf8::basic_string<ValueType, DataType, Allocator>::size_type, tiny_utf8::basic_string<ValueType, DataType, Allocator>::size_type) const [with ValueType = char32_t; DataType = char; Allocator = std::allocator<char>]':
      .../third-party/tiny-utf8/include/tinyutf8/tinyutf8.h:860:4: error: 'lut_width' may be used uninitialized in this function [-Werror=maybe-uninitialized]
        860 |    switch( lut_width ){
            |    ^~~~~~
      .../third-party/tiny-utf8/include/tinyutf8/tinyutf8.h:3643:16: note: 'lut_width' was declared here
       3643 |   width_type   lut_width; // Ignore uninitialized warning, see [5]
            |                ^~~~~~~~~
      cc1plus: all warnings being treated as errors
```

The GCC version I'm using is:

```
gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

After reviewing the code in question I think the warning is incorrect, so this merge request disables it.
What do you think?