### PR TITLE
Implement constructor from and conversion to std::string_view.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(
 target_compile_features(
     ${PROJECT_NAME} 
     INTERFACE 
-        cxx_std_11
+        cxx_std_17
 )
 
 ##############################################

--- a/include/tinyutf8/tinyutf8.h
+++ b/include/tinyutf8/tinyutf8.h
@@ -1210,6 +1210,18 @@ namespace tiny_utf8
 			: basic_string( str.data() , str.size() , alloc , tiny_utf8_detail::read_bytes_tag() )
 		{}
 		/**
+		 * Constructor taking an std::string_view
+		 * 
+		 * @note	Creates an Instance of type basic_string copying the string data from the supplied std::basic_string_view
+		 * @param	str		The string object from which the data will be copied (interpreted as UTF-8)
+		 * @param	alloc	(Optional) The allocator instance to use
+		 */
+		template<typename C>
+		inline basic_string( std::basic_string_view<data_type, C> str , const allocator_type& alloc = allocator_type() )
+			noexcept(TINY_UTF8_NOEXCEPT)
+			: basic_string( str.data() , str.size() , alloc , tiny_utf8_detail::read_bytes_tag() )
+		{}
+		/**
 		 * Constructor taking an std::string
 		 * 
 		 * @note	Creates an Instance of type basic_string copying the string data from the supplied std::basic_string
@@ -2692,6 +2704,15 @@ namespace tiny_utf8
 		 * @return	UTF-8 formatted data, wrapped inside an std::string
 		 */
 		inline std::basic_string<data_type> cpp_str( bool prepend_bom = false ) const noexcept(TINY_UTF8_NOEXCEPT) { return prepend_bom ? cpp_str_bom() : std::basic_string<DataType>( c_str() , size() ); }
+		
+		
+		/**
+		 * Get the raw data contained in this basic_string wrapped by an std::string_view
+		 * 
+		 * @note	Returns the UTF-8 formatted content of this basic_string
+		 * @return	UTF-8 formatted data, wrapped inside an std::string_view
+		 */
+		inline std::basic_string_view<data_type> cpp_str_view() const noexcept(TINY_UTF8_NOEXCEPT) { return std::basic_string_view<DataType>( c_str() , size() ); }
 	};
 } // Namespace 'tiny_utf8'
 

--- a/test/src/test_construction.cpp
+++ b/test/src/test_construction.cpp
@@ -74,6 +74,22 @@ TEST(TinyUTF8, CTor_TakeAnAnsiString)
 	EXPECT_TRUE(str.lut_active());
 }
 
+TEST(TinyUTF8, CTor_TakeAStringView)
+{
+	const std::string str_orig("Löwen, Bären, Vögel und Käfer sind Tiere.");
+	const std::string_view str_view(str_orig);
+	tiny_utf8::string str(str_view);
+
+	EXPECT_EQ(str_view.length(), 45);
+	EXPECT_EQ(str_view.size(), 45);
+	EXPECT_EQ(str.length(), 41);
+	EXPECT_EQ(str.size(), 45);
+
+	EXPECT_TRUE(str.requires_unicode());
+	EXPECT_FALSE(str.sso_active());
+	EXPECT_TRUE(str.lut_active());
+}
+
 TEST(TinyUTF8, CopyCTor)
 {
 	tiny_utf8::string str_orig(U"Hello  ツ  World");

--- a/test/src/test_conversion.cpp
+++ b/test/src/test_conversion.cpp
@@ -18,3 +18,11 @@ TEST(TinyUTF8, ToWideLiteral)
 		++it_fwd;
 	}
 }
+
+TEST(TinyUTF8, ToCppStr)
+{
+	const std::string str_orig("Löwen, Bären, Vögel und Käfer sind Tiere.");
+	tiny_utf8::string str(str_orig);
+	EXPECT_EQ(str.cpp_str(), str_orig);
+	EXPECT_EQ(str.cpp_str_view(), str_orig);
+}


### PR DESCRIPTION
This allows to get rid of various unnecessary copies in my code. E.g., data passed as `std::string_view` can be used to directly construct an UTF-8 string without having to create a temporary `std::string`. Also, it allows to pass the UTF-8 string directly to various functions that accept a `std::string_view`.

I've tried to follow the surrounding code style (including the trailing whitespace). Feel free to let me know if aynthing should be changed (or adjust it yourself, you should have permission to push edits).