### PR TITLE
Fix return type of erase functions.

### DIFF
--- a/include/tinyutf8/tinyutf8.h
+++ b/include/tinyutf8/tinyutf8.h
@@ -2065,8 +2065,9 @@ namespace tiny_utf8
 		 * @param	pos		The iterator pointing to the position being erased
 		 * @return	A reference to this basic_string, which now has the codepoint erased
 		 */
-		inline basic_string& erase( raw_iterator pos ) noexcept(TINY_UTF8_NOEXCEPT) {
-			return raw_erase( pos.get_raw_index() , get_index_bytes( pos.get_raw_index() ) );
+		inline raw_iterator erase( raw_iterator pos ) noexcept(TINY_UTF8_NOEXCEPT) {
+			raw_erase( pos.get_raw_index() , get_index_bytes( pos.get_raw_index() ) );
+			return pos;
 		}
 		/**
 		 * Erases the codepoints inside the supplied range
@@ -2075,12 +2076,22 @@ namespace tiny_utf8
 		 * @param	last	An iterator pointing to the codepoint behind the last codepoint to be erased
 		 * @return	A reference to this basic_string, which now has the codepoints erased
 		 */
-		inline basic_string& erase( raw_iterator first , raw_iterator last ) noexcept(TINY_UTF8_NOEXCEPT) {
-			return raw_erase( first.get_raw_index() , last.get_raw_index() - first.get_raw_index() );
+		inline raw_iterator erase( raw_iterator first , raw_iterator last ) noexcept(TINY_UTF8_NOEXCEPT) {
+			raw_erase( first.get_raw_index() , last.get_raw_index() - first.get_raw_index() );
+			return first;
 		}
-		inline basic_string& erase( raw_iterator first , iterator last ) noexcept(TINY_UTF8_NOEXCEPT) { return erase( first , (raw_iterator)last ); }
-		inline basic_string& erase( iterator first , raw_iterator last ) noexcept(TINY_UTF8_NOEXCEPT) { return erase( (raw_iterator)first , last ); }
-		inline basic_string& erase( iterator first , iterator last ) noexcept(TINY_UTF8_NOEXCEPT) { return erase( (raw_iterator)first , (raw_iterator)last ); }
+		inline raw_iterator erase( raw_iterator first , iterator last ) noexcept(TINY_UTF8_NOEXCEPT) {
+			erase( first , (raw_iterator)last );
+			return first;
+		}
+		inline iterator erase( iterator first , raw_iterator last ) noexcept(TINY_UTF8_NOEXCEPT) {
+			erase( (raw_iterator)first , last );
+			return first;
+		}
+		inline iterator erase( iterator first , iterator last ) noexcept(TINY_UTF8_NOEXCEPT) {
+			erase( (raw_iterator)first , (raw_iterator)last );
+			return first;
+		}
 		/**
 		 * Erases a portion of this string
 		 * 

--- a/test/src/test_manipulation.cpp
+++ b/test/src/test_manipulation.cpp
@@ -96,17 +96,27 @@ TEST(TinyUTF8, EraseString)
 	EXPECT_TRUE(str.sso_active());
 	EXPECT_FALSE(str.lut_active());
 
-	str.erase(14);
+	auto res1 = str.erase(14);
 
+	EXPECT_EQ(res1, str);
 	EXPECT_EQ(str.length(), 14);
 	EXPECT_EQ(str.size(), 16);
 	EXPECT_TRUE(str.requires_unicode());
 	EXPECT_TRUE(str.sso_active());
 
-	str.erase(str.begin(), str.begin() + 9);
+	auto res2 = str.erase(str.begin(), str.begin() + 9);
 
+	EXPECT_EQ(res2, str.begin());
 	EXPECT_EQ(str.length(), 5);
 	EXPECT_EQ(str.size(), 5);
+	EXPECT_FALSE(str.requires_unicode());
+	EXPECT_TRUE(str.sso_active());
+
+	auto res3 = str.erase(str.begin() + 2);
+
+	EXPECT_EQ(res3, str.begin() + 2);
+	EXPECT_EQ(str.length(), 4);
+	EXPECT_EQ(str.size(), 4);
 	EXPECT_FALSE(str.requires_unicode());
 	EXPECT_TRUE(str.sso_active());
 }


### PR DESCRIPTION
For best compatibility with `std::string`, the return value should probably also be an iterator.