### PR TITLE
Fix some (not all) C++23 errors

### DIFF
--- a/include/tinyutf8/tinyutf8.h
+++ b/include/tinyutf8/tinyutf8.h
@@ -2374,10 +2374,11 @@ namespace tiny_utf8
 		bool starts_with( const value_type (&str)[LITLEN] ) const noexcept {
 			size_type		str_len = str[LITLEN-1] ? LITLEN : LITLEN-1;
 			const_iterator	it = cbegin(), end = cend();
+			value_type const* str_ptr = str;
 			while( it != end && str_len ){
 				if( *it != *str )
 					return false;
-				++it, ++str, --str_len;
+				++it, ++str_ptr, --str_len;
 			}
 			return !str_len;
 		}
@@ -2760,7 +2761,7 @@ template<typename V, typename D, typename A>
 std::istream& operator>>( std::istream& stream , tiny_utf8::basic_string<V, D, A>& str ) noexcept(TINY_UTF8_NOEXCEPT) {
 	std::string tmp;
 	stream >> tmp;
-	str = move(tmp);
+	str = std::move(tmp);
 	return stream;
 }
 


### PR DESCRIPTION
This fixes the C++23 main code compile errors, but I can't get the tests to compile due to [this error](https://github.com/DuffsDevice/tiny-utf8/issues/79).

Fixes https://github.com/DuffsDevice/tiny-utf8/issues/71